### PR TITLE
add argument type read only array to intersection

### DIFF
--- a/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/ramda_v0.26.x.js
@@ -1301,8 +1301,8 @@ declare module ramda {
     b: Array<B>
   ): Array<A>;
 
-  declare function intersection<T>(xs: $ReadOnlyArray<T>, ys: $ReadOnlyArray<T>): $ReadOnlyArray<T>;
-  declare function intersection<T>(xs: $ReadOnlyArray<T>): (ys: $ReadOnlyArray<T>) => $ReadOnlyArray<T>;
+  declare function intersection<T>(xs: $ReadOnlyArray<T>, ys: $ReadOnlyArray<T>): Array<T>;
+  declare function intersection<T>(xs: $ReadOnlyArray<T>): (ys: $ReadOnlyArray<T>) => Array<T>;
 
   declare function max<T>(x: T): (y: T) => T;
   declare function max<T>(x: T, y: T): T;

--- a/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/ramda_v0.26.x.js
@@ -1301,8 +1301,8 @@ declare module ramda {
     b: Array<B>
   ): Array<A>;
 
-  declare function intersection<T>(xs: Array<T> | $ReadOnlyArray<T>, ys: Array<T> | $ReadOnlyArray<T>): Array<T> | $ReadOnlyArray<T>;
-  declare function intersection<T>(xs: Array<T> | $ReadOnlyArray<T>): (ys: Array<T> | $ReadOnlyArray<T>) => Array<T> | $ReadOnlyArray<T>;
+  declare function intersection<T>(xs: $ReadOnlyArray<T>, ys: $ReadOnlyArray<T>): $ReadOnlyArray<T>;
+  declare function intersection<T>(xs: $ReadOnlyArray<T>): (ys: $ReadOnlyArray<T>) => $ReadOnlyArray<T>;
 
   declare function max<T>(x: T): (y: T) => T;
   declare function max<T>(x: T, y: T): T;

--- a/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/ramda_v0.26.x.js
@@ -1301,8 +1301,8 @@ declare module ramda {
     b: Array<B>
   ): Array<A>;
 
-  declare function intersection<T>(x: Array<T>, y: Array<T>): Array<T>;
-  declare function intersection<T>(x: Array<T>): (y: Array<T>) => Array<T>;
+  declare function intersection<T>(xs: Array<T> | $ReadOnlyArray<T>, ys: Array<T> | $ReadOnlyArray<T>): Array<T> | $ReadOnlyArray<T>;
+  declare function intersection<T>(xs: Array<T> | $ReadOnlyArray<T>): (ys: Array<T> | $ReadOnlyArray<T>) => Array<T> | $ReadOnlyArray<T>;
 
   declare function max<T>(x: T): (y: T) => T;
   declare function max<T>(x: T, y: T): T;

--- a/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/test_ramda_v0.26.x_relation.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/test_ramda_v0.26.x_relation.js
@@ -232,7 +232,7 @@ const _innerJoin: Array<{ [k: string]: mixed, ... }> = _.innerJoin(
   [177, 456, 999]
 );
 
-const inters: Array<number> = _.intersection(ns, ns);
+const inters: $ReadOnlyArray<number> = _.intersection(ns, ns);
 
 const pathEqObj: boolean = _.pathEq(["b", 1], 1, objArr);
 const pathEqObj2: boolean = _.pathEq(["b", 1])(1)(objArr);

--- a/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/test_ramda_v0.26.x_relation.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/test_ramda_v0.26.x_relation.js
@@ -10,6 +10,7 @@ import _, {
   find,
   gt,
   gte,
+  intersection,
   lt,
   lte,
   pipe,
@@ -232,8 +233,6 @@ const _innerJoin: Array<{ [k: string]: mixed, ... }> = _.innerJoin(
   [177, 456, 999]
 );
 
-const inters: $ReadOnlyArray<number> = _.intersection(ns, ns);
-
 const pathEqObj: boolean = _.pathEq(["b", 1], 1, objArr);
 const pathEqObj2: boolean = _.pathEq(["b", 1])(1)(objArr);
 
@@ -314,3 +313,19 @@ const sym: Array<number> = _.symmetricDifference([1, 2, 3, 4], [7, 6, 5, 4, 3]);
 
 const un: Array<number> = _.union([1, 2, 3])([2, 3, 4]);
 const un1: Array<{ [k: string]: number, ... }> = _.unionWith(eqA, ls1, ls2);
+
+// Given $ReadOnlyArray is super type of Array, no need to test Array -> $ReadOnlyArray case
+describe('intersection', () => {
+  const readOnlyArray: $ReadOnlyArray<number> = [1, 2, 3]
+  it('should only accept read only input', () => {
+    const inters1: $ReadOnlyArray<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters2: $ReadOnlyArray<number> = intersection(readOnlyArray)(readOnlyArray)
+  });
+
+  it('should error out when output is not read only', () => {
+    //$ExpectError
+    const inters3: Array<number> = intersection(readOnlyArray, readOnlyArray)
+    //$ExpectError
+    const inters4: Array<number> = intersection(readOnlyArray)(readOnlyArray)
+  });
+})

--- a/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/test_ramda_v0.26.x_relation.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/test_ramda_v0.26.x_relation.js
@@ -316,16 +316,19 @@ const un1: Array<{ [k: string]: number, ... }> = _.unionWith(eqA, ls1, ls2);
 
 // Given $ReadOnlyArray is super type of Array, no need to test Array -> $ReadOnlyArray case
 describe('intersection', () => {
-  const readOnlyArray: $ReadOnlyArray<number> = [1, 2, 3]
-  it('should only accept read only input', () => {
-    const inters1: $ReadOnlyArray<number> = intersection(readOnlyArray, readOnlyArray)
-    const inters2: $ReadOnlyArray<number> = intersection(readOnlyArray)(readOnlyArray)
+  it('should accept read only input', () => {
+    const readOnlyArray: $ReadOnlyArray<number> = [1, 2, 3]
+    const inters1: Array<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters2: Array<number> = intersection(readOnlyArray)(readOnlyArray)
+    const inters3: $ReadOnlyArray<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters4: $ReadOnlyArray<number> = intersection(readOnlyArray)(readOnlyArray)
   });
 
-  it('should error out when output is not read only', () => {
-    //$ExpectError
-    const inters3: Array<number> = intersection(readOnlyArray, readOnlyArray)
-    //$ExpectError
-    const inters4: Array<number> = intersection(readOnlyArray)(readOnlyArray)
+  it('should allow mutable array in and out', () => {
+    const readOnlyArray: Array<number> = [1, 2, 3]
+    const inters1: Array<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters2: Array<number> = intersection(readOnlyArray)(readOnlyArray)
+    const inters3: $ReadOnlyArray<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters4: $ReadOnlyArray<number> = intersection(readOnlyArray)(readOnlyArray)
   });
 })

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/ramda_v0.26.x.js
@@ -1267,8 +1267,8 @@ declare module ramda {
     b: Array<B>
   ): Array<A>;
 
-  declare function intersection<T>(x: Array<T>, y: Array<T>): Array<T>;
-  declare function intersection<T>(x: Array<T>): (y: Array<T>) => Array<T>;
+  declare function intersection<T>(xs: Array<T> | $ReadOnlyArray<T>, ys: Array<T> | $ReadOnlyArray<T>): Array<T> | $ReadOnlyArray<T>;
+  declare function intersection<T>(xs: Array<T> | $ReadOnlyArray<T>): (ys: Array<T> | $ReadOnlyArray<T>) => Array<T> | $ReadOnlyArray<T>;
 
   declare function max<T>(x: T): (y: T) => T;
   declare function max<T>(x: T, y: T): T;

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/ramda_v0.26.x.js
@@ -1267,8 +1267,8 @@ declare module ramda {
     b: Array<B>
   ): Array<A>;
 
-  declare function intersection<T>(xs: Array<T> | $ReadOnlyArray<T>, ys: Array<T> | $ReadOnlyArray<T>): Array<T> | $ReadOnlyArray<T>;
-  declare function intersection<T>(xs: Array<T> | $ReadOnlyArray<T>): (ys: Array<T> | $ReadOnlyArray<T>) => Array<T> | $ReadOnlyArray<T>;
+  declare function intersection<T>(xs: $ReadOnlyArray<T>, ys: $ReadOnlyArray<T>): $ReadOnlyArray<T>;
+  declare function intersection<T>(xs: $ReadOnlyArray<T>): (ys: $ReadOnlyArray<T>) => $ReadOnlyArray<T>;
 
   declare function max<T>(x: T): (y: T) => T;
   declare function max<T>(x: T, y: T): T;

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/ramda_v0.26.x.js
@@ -1267,8 +1267,8 @@ declare module ramda {
     b: Array<B>
   ): Array<A>;
 
-  declare function intersection<T>(xs: $ReadOnlyArray<T>, ys: $ReadOnlyArray<T>): $ReadOnlyArray<T>;
-  declare function intersection<T>(xs: $ReadOnlyArray<T>): (ys: $ReadOnlyArray<T>) => $ReadOnlyArray<T>;
+  declare function intersection<T>(xs: $ReadOnlyArray<T>, ys: $ReadOnlyArray<T>): Array<T>;
+  declare function intersection<T>(xs: $ReadOnlyArray<T>): (ys: $ReadOnlyArray<T>) => Array<T>;
 
   declare function max<T>(x: T): (y: T) => T;
   declare function max<T>(x: T, y: T): T;

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_relation.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_relation.js
@@ -232,7 +232,7 @@ const _innerJoin: Array<{ [k: string]: mixed }> = _.innerJoin(
   [177, 456, 999]
 );
 
-const inters: Array<number> = _.intersection(ns, ns);
+const inters: $ReadOnlyArray<number> = _.intersection(ns, ns);
 
 const pathEqObj: boolean = _.pathEq(["b", 1], 1, objArr);
 const pathEqObj2: boolean = _.pathEq(["b", 1])(1)(objArr);

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_relation.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_relation.js
@@ -310,18 +310,21 @@ const sym: Array<number> = _.symmetricDifference([1, 2, 3, 4], [7, 6, 5, 4, 3]);
 const un: Array<number> = _.union([1, 2, 3])([2, 3, 4]);
 const un1: Array<{ [k: string]: number }> = _.unionWith(eqA, ls1, ls2);
 
+// Given $ReadOnlyArray is super type of Array, no need to test Array -> $ReadOnlyArray case
 describe('intersection', () => {
-  const readOnlyArray: $ReadOnlyArray<number> = [1, 2, 3]
-  it('should only accept read only input', () => {
-    const inters1: $ReadOnlyArray<number> = intersection(readOnlyArray, readOnlyArray)
-    const inters2: $ReadOnlyArray<number> = intersection(readOnlyArray)(readOnlyArray)
+  it('should accept read only input', () => {
+    const readOnlyArray: $ReadOnlyArray<number> = [1, 2, 3]
+    const inters1: Array<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters2: Array<number> = intersection(readOnlyArray)(readOnlyArray)
+    const inters3: $ReadOnlyArray<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters4: $ReadOnlyArray<number> = intersection(readOnlyArray)(readOnlyArray)
   });
 
-  // Given $ReadOnlyArray is super type of Array, no need to test Array -> $ReadOnlyArray case
-  it('should error out when output is not read only', () => {
-    //$ExpectError
-    const inters3: Array<number> = intersection(readOnlyArray, readOnlyArray)
-    //$ExpectError
-    const inters4: Array<number> = intersection(readOnlyArray)(readOnlyArray)
+  it('should allow mutable array in and out', () => {
+    const readOnlyArray: Array<number> = [1, 2, 3]
+    const inters1: Array<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters2: Array<number> = intersection(readOnlyArray)(readOnlyArray)
+    const inters3: $ReadOnlyArray<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters4: $ReadOnlyArray<number> = intersection(readOnlyArray)(readOnlyArray)
   });
 })

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_relation.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_relation.js
@@ -10,6 +10,7 @@ import _, {
   find,
   gt,
   gte,
+  intersection,
   lt,
   lte,
   pipe,
@@ -232,8 +233,6 @@ const _innerJoin: Array<{ [k: string]: mixed }> = _.innerJoin(
   [177, 456, 999]
 );
 
-const inters: $ReadOnlyArray<number> = _.intersection(ns, ns);
-
 const pathEqObj: boolean = _.pathEq(["b", 1], 1, objArr);
 const pathEqObj2: boolean = _.pathEq(["b", 1])(1)(objArr);
 
@@ -310,3 +309,19 @@ const sym: Array<number> = _.symmetricDifference([1, 2, 3, 4], [7, 6, 5, 4, 3]);
 
 const un: Array<number> = _.union([1, 2, 3])([2, 3, 4]);
 const un1: Array<{ [k: string]: number }> = _.unionWith(eqA, ls1, ls2);
+
+describe('intersection', () => {
+  const readOnlyArray: $ReadOnlyArray<number> = [1, 2, 3]
+  it('should only accept read only input', () => {
+    const inters1: $ReadOnlyArray<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters2: $ReadOnlyArray<number> = intersection(readOnlyArray)(readOnlyArray)
+  });
+
+  // Given $ReadOnlyArray is super type of Array, no need to test Array -> $ReadOnlyArray case
+  it('should error out when output is not read only', () => {
+    //$ExpectError
+    const inters3: Array<number> = intersection(readOnlyArray, readOnlyArray)
+    //$ExpectError
+    const inters4: Array<number> = intersection(readOnlyArray)(readOnlyArray)
+  });
+})


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://ramdajs.com/docs/
- Link to GitHub or NPM: https://github.com/ramda/ramda
- Type of contribution: refactor
Other notes:
Refactor intersection to take ready only input, $ReadOnlyArray is super type of Array, so it satisfies everything in Array, except it has fewer methods on it.
