### PR TITLE
Redux devtools extension fix

### DIFF
--- a/definitions/npm/redux-devtools-extension_v2.x.x/flow_v0.104.x-/redux-devtools-extension_v2.x.x.js
+++ b/definitions/npm/redux-devtools-extension_v2.x.x/flow_v0.104.x-/redux-devtools-extension_v2.x.x.js
@@ -1,5 +1,37 @@
-import type { ActionCreator, StoreEnhancer } from 'redux';
-import typeof { compose } from 'redux';
+// Following type definitions are copied from redux_v4 plus inexact type addition to satisfy tests
+// start
+declare type DispatchAPI<A> = (action: A) => A;
+
+declare type Dispatch<A: { type: *, ... }> = DispatchAPI<A>;
+
+declare type Store<S, A, D = Dispatch<A>> = {
+  // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+  dispatch: D,
+  getState(): S,
+  subscribe(listener: () => void): () => void,
+  replaceReducer(nextReducer: Reducer<S, A>): void,
+  ...
+};
+
+declare type Reducer<S, A> = (state: S | void, action: A) => S;
+
+declare type ActionCreator<A, B> = (...args: Array<B>) => A;
+
+declare type StoreCreator<S, A, D = Dispatch<A>> = {
+  (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
+  (
+    reducer: Reducer<S, A>,
+    preloadedState: S,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>,
+  ...
+};
+declare type StoreEnhancer<S, A, D = Dispatch<A>> = (
+   next: StoreCreator<S, A, D>
+ ) => StoreCreator<S, A, D>;
+// end
+
+declare type ReduxCompose = $Compose;
 
 declare type $npm$ReduxDevtoolsExtension$DevToolsOptions = {
   name?: string,
@@ -94,7 +126,7 @@ declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B, C, D, E, 
   cd: C => D,
   bc: B => C,
   ab: A => B
-): A => H;
+): A => I;
 
 declare function $npm$ReduxDevtoolsExtension$devToolsEnhancer<S, A>(options?: $npm$ReduxDevtoolsExtension$DevToolsOptions): StoreEnhancer<S, A>;
 

--- a/definitions/npm/redux-devtools-extension_v2.x.x/flow_v0.104.x-/redux-devtools-extension_v2.x.x.js
+++ b/definitions/npm/redux-devtools-extension_v2.x.x/flow_v0.104.x-/redux-devtools-extension_v2.x.x.js
@@ -76,8 +76,9 @@ declare type $npm$ReduxDevtoolsExtension$DevToolsOptions = {
   ...
 };
 
+declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B>(options: $npm$ReduxDevtoolsExtension$DevToolsOptions| A): B & $Compose;
 declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B>(ab: A => B): A => B;
-declare function $npm$ReduxDevtoolsExtension$composeWithDevTools(options: $npm$ReduxDevtoolsExtension$DevToolsOptions): compose;
+
 declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B, C>(
   bc: B => C,
   ab: A => B

--- a/definitions/npm/redux-devtools-extension_v2.x.x/test_redux-devtools-extension_v2.x.x.js
+++ b/definitions/npm/redux-devtools-extension_v2.x.x/test_redux-devtools-extension_v2.x.x.js
@@ -66,8 +66,8 @@ const options5: OptionsLogProd = {
 (compose: typeof composeLog);
 (compose: typeof composeLogProd);
 
-(compose(options1): Function);
-(compose(options1): * => Function);
+(compose(options1): $Compose);
+(compose(options1): () => mixed);
 (compose((x: number): boolean => x === 0): number => boolean);
 (compose((b: boolean): Array<number> => b?[0]:[], (x: number): boolean => x === 0): number => Array<number>);
 // $ExpectError


### PR DESCRIPTION
- Links to documentation: https://github.com/zalmoxisus/redux-devtools-extension
- Link to GitHub or NPM: https://github.com/zalmoxisus/redux-devtools-extension
- Type of contribution: refactor

Other notes:
Reason not to do direct import
https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md#dont-import-types-from-other-libdefs

Also fixed a definition typo for function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B, C, D, E, F, G, H, I>, where the return type was wrong I suppose.
